### PR TITLE
Update prom_deploy.yaml

### DIFF
--- a/gmp_prom_setup/prom_deploy.yaml
+++ b/gmp_prom_setup/prom_deploy.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: monitoring.googleapis.com/v1alpha1
+apiVersion: monitoring.googleapis.com/v1
 kind: PodMonitoring
 metadata:
   name: prom-example


### PR DESCRIPTION
Update api version based on warning

`Warning: monitoring.googleapis.com/v1alpha1 PodMonitoring is deprecated; use monitoring.googleapis.com/v1 PodMonitoring`

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR